### PR TITLE
Always use the latest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,18 +16,19 @@
 ## Copyright (C) 2016 - 2023  Dirk Eddelbuettel
 ## and released under GPL (>=2 )
 
-ttfsrc=https://github.com/intel/intel-one-mono/releases/download/V1.2.0/ttf.zip
-otfsrc=https://github.com/intel/intel-one-mono/releases/download/V1.2.0/otf.zip
-ttfout=$(shell basename ${ttfsrc})
-otfout=$(shell basename ${otfsrc})
+repo_base=https://github.com/intel/intel-one-mono
+ttfarchive=ttf.zip
+otfarchive=otf.zip
+ttfurl=${repo_base}/releases/latest/download/${ttfarchive}
+otfurl=${repo_base}/releases/latest/download/${otfarchive}
 
 all:
-	test -f ${ttfout} || wget ${ttfsrc}
-	unzip ${ttfout}
-	test -f ${otfout} || wget ${otfsrc}
-	unzip ${otfout}
+	test -f ${ttfarchive} || curl -L --remote-name ${ttfurl}
+	unzip ${ttfarchive}
+	test -f ${otfarchive} || curl -L --remote-name ${otfurl}
+	unzip ${otfarchive}
 	rm -rf __MACOSX/ ?tf/.DS_Store
 
 clean:
-	rm -f ${ttfout} ${otfout}
+	rm -f ${ttfarchive} ${otfarchive}
 	rm -rf ttf/ otf/

--- a/debian/changelog.template
+++ b/debian/changelog.template
@@ -1,4 +1,4 @@
-fonts-intel-one-mono (1.2.0-0local1) unstable; urgency=low
+fonts-intel-one-mono (VERSION-0local1) unstable; urgency=low
 
   * Initial "local" package -- not uploaded to Debian as it is not
     entirely clear what the copyright situation for the toolchain is

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: fonts-intel-one-mono
 Section: fonts
 Priority: optional
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
-Build-Depends: debhelper-compat (= 12), wget
+Build-Depends: debhelper-compat (= 12), curl
 Standards-Version: 4.6.2
 Homepage: https://github.com/intel/intel-one-mono/
 

--- a/runMe.sh
+++ b/runMe.sh
@@ -1,2 +1,9 @@
 #!/bin/bash
+repo_base=https://github.com/intel/intel-one-mono
+release_url=$(curl -Ls -o /dev/null -w %{url_effective} ${repo_base}/releases/latest)
+release_tag=$(basename ${release_url})
+cat debian/changelog.template | sed -E "s|VERSION|${release_tag#V}|" > debian/changelog
+
 dpkg-buildpackage -rfakeroot -us -uc -tc
+
+rm -f debian/changelog


### PR DESCRIPTION
Instead of relying on a static version (which was multiple releases out of date) I've replaced the static url with a dynamically generated version. I've also switched to curl as it allows the version to be easily extracted from the url.